### PR TITLE
Add configurable tunnel name

### DIFF
--- a/addon-cloudflare-argo/cloudflareargo/config.json
+++ b/addon-cloudflare-argo/cloudflareargo/config.json
@@ -1,6 +1,6 @@
 {
 	"name": "Cloudflare Argo",
-	"version": "2.0",
+	"version": "2.1",
 	"slug": "argocloudflare",
 	"description": "Argo for Home Assistant",
 	"url": "https://github.com/wlatic/hassio.addons/blob/master/cloudflareargo/readme.md",
@@ -22,6 +22,7 @@
 	"options": {
 		
 			"certificate": "/config/cert/argo.pem",
+			"tunnel_name": "homeassistant",
 			"hostname": "host",
 			"service": "http://hassio:8123",
 			"hostname2": "null",

--- a/addon-cloudflare-argo/cloudflareargo/config.json
+++ b/addon-cloudflare-argo/cloudflareargo/config.json
@@ -33,6 +33,7 @@
 	},
 	 "schema": {
     "certificate": "str",
+	"tunnel_name": "str",
     "hostname": "str",
     "service": "str",
     "hostname2": "str",

--- a/addon-cloudflare-argo/cloudflareargo/config.json
+++ b/addon-cloudflare-argo/cloudflareargo/config.json
@@ -8,38 +8,36 @@
 	"panel_icon": "mdi:docker",
 	"homeassistant": "0.104.0",
 	"arch": [
-    "aarch64",
-    "amd64",
-    "armhf",
-    "armv7"
-  ],
+		"aarch64",
+		"amd64",
+		"armhf",
+		"armv7"
+	],
 	"map": [
-         "config:rw"
-  ],
-
+		"config:rw"
+	],
 	"startup": "services",
 	"boot": "auto",
 	"options": {
-		
-			"certificate": "/config/cert/argo.pem",
-			"tunnel_name": "homeassistant",
-			"hostname": "host",
-			"service": "http://hassio:8123",
-			"hostname2": "null",
-			"service2": "null",
-			"hostname3": "null",
-			"service3": "null",
-			"addconfig": "null"
+		"certificate": "/config/cert/argo.pem",
+		"tunnel_name": "homeassistant",
+		"hostname": "host",
+		"service": "http://hassio:8123",
+		"hostname2": "null",
+		"service2": "null",
+		"hostname3": "null",
+		"service3": "null",
+		"addconfig": "null"
 	},
-	 "schema": {
-    "certificate": "str",
-	"tunnel_name": "str",
-    "hostname": "str",
-    "service": "str",
-    "hostname2": "str",
-    "service2": "str",
-    "hostname3": "str",
-    "service3": "str",
-    "addconfig": "str"
-  }
+	"schema": {
+		"certificate": "str",
+		"tunnel_name": "str",
+		"hostname": "str",
+		"service": "str",
+		"hostname2": "str",
+		"service2": "str",
+		"hostname3": "str",
+		"service3": "str",
+		"addconfig": "str"
+	}
 }

--- a/addon-cloudflare-argo/cloudflareargo/rootfs/etc/cont-init.d/cloudflare.sh
+++ b/addon-cloudflare-argo/cloudflareargo/rootfs/etc/cont-init.d/cloudflare.sh
@@ -29,7 +29,7 @@ service3=$(bashio::config 'service3')
 addconfig=$(bashio::config 'addconfig')
 
 if bashio::config.has_value 'hostname'; then
-echo -e "tunnel: homeassistant\ncredentials-file: /config/cf-argo/cf-ha.json\n\ningress:\n  - hostname: ${hostname}\n    service: ${service}\n" > /config/cf-argo/config.yml
+echo -e "tunnel: $(bashio::config 'tunnel_name')\ncredentials-file: /config/cf-argo/cf-ha.json\n\ningress:\n  - hostname: ${hostname}\n    service: ${service}\n" > /config/cf-argo/config.yml
 fi
 
 if bashio::config.has_value 'hostname2'; then

--- a/addon-cloudflare-argo/cloudflareargo/rootfs/etc/cont-init.d/cloudflare.sh
+++ b/addon-cloudflare-argo/cloudflareargo/rootfs/etc/cont-init.d/cloudflare.sh
@@ -9,7 +9,7 @@ if ! bashio::fs.directory_exists '/config/cf-argo/'; then
 fi
 
 if ! bashio::fs.file_exists "/config/cf-argo/cf-ha.json"; then
-/opt/cloudflared --origincert=${certificate} --cred-file=/config/cf-argo/cf-ha.json tunnel create homeassistant
+/opt/cloudflared --origincert=${certificate} --cred-file=/config/cf-argo/cf-ha.json tunnel create $(bashio::config 'tunnel_name')
 fi
 
 declare hostname

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
   "name": "Wlatic HA Repo - Fork",
-  "url": "https://github.com/jwsample/hassio.addons",
+  "url": "https://github.com/wlatic/hassio.addons",
   "maintainer": "Wlatic"
 }

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
-  "name": "Wlatic HA Repo - Fork",
+  "name": "Wlatic HA Repo",
   "url": "https://github.com/wlatic/hassio.addons",
   "maintainer": "Wlatic"
 }

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
-  "name": "Wlatic HA Repo",
+  "name": "Wlatic HA Repo - Fork",
   "url": "https://github.com/wlatic/hassio.addons",
   "maintainer": "Wlatic"
 }

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
   "name": "Wlatic HA Repo - Fork",
-  "url": "https://github.com/wlatic/hassio.addons",
+  "url": "https://github.com/jwsample/hassio.addons",
   "maintainer": "Wlatic"
 }


### PR DESCRIPTION
To get around the unique Argo Tunnel name constraints this patch adds a configurable tunnel name.
It defaults to "homeassistant" but must be changed if the user has more than one Home Assistant instance in the same Cloudflare account.

